### PR TITLE
Force cgroup v2 with systemd-nspawn to support RPi OS bookworm

### DIFF
--- a/.github/workflows/test-pinspawn.yml
+++ b/.github/workflows/test-pinspawn.yml
@@ -184,3 +184,14 @@ jobs:
             if [ "$USER" != "pi" ]; then
               exit 666
             fi
+
+      # Check cgroup version
+
+      - name: Run as user in booted container
+        uses: ./
+        with:
+          # Note: this test should be run on a bookworm image to exercise the required functionality
+          image: rpi-os-image.img
+          boot: true
+          run: |
+            mount | grep cgroup2

--- a/.github/workflows/test-pinspawn.yml
+++ b/.github/workflows/test-pinspawn.yml
@@ -187,11 +187,13 @@ jobs:
 
       # Check cgroup version
 
-      - name: Run as user in booted container
+      - name: Confirm use of cgroup v2
         uses: ./
         with:
           # Note: this test should be run on a bookworm image to exercise the required functionality
           image: rpi-os-image.img
           boot: true
           run: |
+            #!/bin/sh -e
+            echo "cgroup v2 mount:"
             mount | grep cgroup2

--- a/pinspawn.sh
+++ b/pinspawn.sh
@@ -166,18 +166,14 @@ if [ ! -z "$boot_run_service" ]; then
       systemctl mask userconfig.service
   fi
 
-# Mask userconfig.service
-tmp_userconfig_enabled="$(sudo mktemp --tmpdir="$sysroot/var/lib" piqemu-userconfig-enabled.XXXXXXX)"
-sudo systemd-nspawn --directory "$sysroot" --quiet \
-  bash -c "systemctl is-enabled userconfig.service | sudo tee \"${tmp_userconfig_enabled#"$sysroot"}\" > /dev/null || true"
-userconfig_enabled="$(sudo cat "$tmp_userconfig_enabled")"
-sudo rm "$tmp_userconfig_enabled"
-if [[ "$userconfig_enabled" != "not-found" && "$userconfig_enabled" != masked* ]]; then
-  sudo systemd-nspawn --directory "$sysroot" --quiet \
-    systemctl mask userconfig.service
-fi
-
   echo "Running container with boot..."
+  # Note: we force systemd to boot with cgroup v2 (needed for Docker to start), since systemd is
+  # unable to automatically detect cgroup v2 support in RPi OS bookworm for some reason. This should
+  # be fine on RPi OS images since bullseye supports cgroup v2 (and its support is correctly
+  # detected by systemd-nspawn), and we don't really care to support anything older than that.
+  # See https://github.com/NixOS/nixpkgs/issues/196413 for details on this workaround, and on the
+  # errors which occur without this workaround
+  export SYSTEMD_NSPAWN_UNIFIED_HIERARCHY=1
   # We use eval to work around word splitting in strings inside quotes in args:
   eval "sudo systemd-nspawn --directory \"$sysroot\" $args"
 else

--- a/pinspawn.sh
+++ b/pinspawn.sh
@@ -175,7 +175,7 @@ if [ ! -z "$boot_run_service" ]; then
   # errors which occur without this workaround
   export SYSTEMD_NSPAWN_UNIFIED_HIERARCHY=1
   # We use eval to work around word splitting in strings inside quotes in args:
-  eval "sudo systemd-nspawn --directory \"$sysroot\" $args"
+  eval "sudo --preserve-env=SYSTEMD_NSPAWN_UNIFIED_HIERARCHY systemd-nspawn --directory \"$sysroot\" $args"
 else
   # We can't boot if a non-root user is set, so we only set this flag for unbooted containers:
   if [ ! -z "$user" ]; then


### PR DESCRIPTION
For some reason, by default systemd-nspawn decides to use v1 cgroup instead of v2 cgroup on RPi OS bookworm images (this problem doesn't occur on RPi OS bullseye images, even though they're older). This PR sets the [`SYSTEMD_NSPAWN_UNIFIED_HIERARCHY` environment variable](https://github.com/systemd/systemd/blob/main/docs/ENVIRONMENT.md) when invoking a booted container with systemd-nspawn, in order to force systemd to set up v2 cgroup regardless of the image.

See https://github.com/NixOS/nixpkgs/issues/196413 for details on the symptom and workaround underlying this PR.