### PR TITLE
Add example of running Docker in container on arm64 runner

### DIFF
--- a/.github/workflows/test-pinspawn.yml
+++ b/.github/workflows/test-pinspawn.yml
@@ -222,3 +222,41 @@ jobs:
             #!/bin/sh -e
             echo "cgroup v2 mount:"
             mount | grep cgroup2
+
+      # Interact with Docker in an unbooted container
+
+      - name: Install Docker
+        uses: ./
+        if: ${{ endsWith(matrix.os, '-arm') }}
+        with:
+          image: rpi-os-image.img
+          run: |
+            export DEBIAN_FRONTEND=noninteractive
+            apt-get update
+            apt-get install -y ca-certificates curl
+            install -m 0755 -d /etc/apt/keyrings
+            curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc
+            chmod a+r /etc/apt/keyrings/docker.asc
+            echo \
+              "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian \
+              $(. /etc/os-release && echo "$VERSION_CODENAME") stable" \
+              > /etc/apt/sources.list.d/docker.list
+            apt-get update
+            apt-get install -y \
+              docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+
+      - name: Pull and run a container
+        uses: ./
+        if: ${{ endsWith(matrix.os, '-arm') }}
+        with:
+          image: rpi-os-image.img
+          args: --capability=CAP_NET_ADMIN
+          run: |
+            /usr/bin/containerd &
+            /usr/bin/dockerd &
+            sleep 10
+
+            docker pull cgr.dev/chainguard/crane:latest
+            docker images cgr.dev/chainguard/crane
+            docker run --pull=never --rm cgr.dev/chainguard/crane:latest \
+              manifest cgr.dev/chainguard/crane:latest --platform=linux/amd64

--- a/.github/workflows/test-pinspawn.yml
+++ b/.github/workflows/test-pinspawn.yml
@@ -246,7 +246,7 @@ jobs:
             apt-get install -y \
               docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
 
-      - name: Inspect a Docker container image
+      - name: Run a Docker container image
         uses: ./
         if: ${{ endsWith(matrix.os, '24.04-arm') }}
         with:
@@ -255,10 +255,9 @@ jobs:
           run: |
             #!/bin/bash -eux
 
-            docker manifest inspect cgr.dev/chainguard/crane:latest
-
             /usr/bin/containerd &
             /usr/bin/dockerd &
             sleep 10
 
-            docker manifest inspect cgr.dev/chainguard/crane:latest
+            docker run hello-world
+            docker images hello-world

--- a/.github/workflows/test-pinspawn.yml
+++ b/.github/workflows/test-pinspawn.yml
@@ -19,7 +19,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, ubuntu-24.04, ubuntu-22.04-arm, ubuntu-24.04-arm]
+        os:
+          - ubuntu-22.04
+          - ubuntu-24.04
+          - ubuntu-22.04-arm
+          - ubuntu-24.04-arm
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository
@@ -153,6 +157,7 @@ jobs:
 
       - name: Analyze systemd boot process
         uses: ./
+        if: ${{ endsWith(matrix.os, '-arm') }}
         with:
           image: rpi-os-image.img
           args: --bind "$(pwd)":/run/external
@@ -169,6 +174,7 @@ jobs:
 
       - name: Upload the bootup timeline to Job Artifacts
         uses: actions/upload-artifact@v4
+        if: ${{ endsWith(matrix.os, '-arm') }}
         with:
           name: bootup-timeline
           path: bootup-timeline.svg
@@ -193,6 +199,7 @@ jobs:
 
       - name: Run slow script in booted container
         uses: ./
+        if: ${{ endsWith(matrix.os, '-arm') }}
         with:
           image: rpi-os-image.img
           boot: true

--- a/.github/workflows/test-pinspawn.yml
+++ b/.github/workflows/test-pinspawn.yml
@@ -238,14 +238,15 @@ jobs:
             curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc
             chmod a+r /etc/apt/keyrings/docker.asc
             echo \
-              "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian \
+              "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] \
+              https://download.docker.com/linux/debian \
               $(. /etc/os-release && echo "$VERSION_CODENAME") stable" \
               > /etc/apt/sources.list.d/docker.list
             apt-get update
             apt-get install -y \
               docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
 
-      - name: Pull and run a container
+      - name: Pull and run a Docker container
         uses: ./
         if: ${{ endsWith(matrix.os, '-arm') }}
         with:
@@ -256,6 +257,9 @@ jobs:
             /usr/bin/dockerd &
             sleep 10
 
+            # Note: GitHub's arm64 runner is armv8, but crane only has armv7 images; so we instead
+            # run the armv7 image.
+            export DOCKER_DEFAULT_PLATFORM=linux/arm/v7
             docker pull cgr.dev/chainguard/crane:latest
             docker images cgr.dev/chainguard/crane
             docker run --pull=never --rm cgr.dev/chainguard/crane:latest \

--- a/.github/workflows/test-pinspawn.yml
+++ b/.github/workflows/test-pinspawn.yml
@@ -33,8 +33,8 @@ jobs:
         id: download-base
         uses: ethanjli/cached-download-action@v0.1.1
         with:
-          url: https://downloads.raspberrypi.com/raspios_lite_armhf/images/raspios_lite_armhf-2024-11-19/2024-11-19-raspios-bookworm-armhf-lite.img.xz
-          destination: /tmp/2024-11-19-raspios-bookworm-armhf-lite.img.xz
+          url: https://downloads.raspberrypi.com/raspios_lite_arm64/images/raspios_lite_arm64-2024-11-19/2024-11-19-raspios-bookworm-arm64-lite.img.xz
+          destination: /tmp/2024-11-19-raspios-bookworm-arm64-lite.img.xz
 
       - name: Grow the image
         id: grow-image
@@ -257,9 +257,6 @@ jobs:
             /usr/bin/dockerd &
             sleep 10
 
-            # Note: GitHub's arm64 runner is armv8, but crane only has armv7 images; so we instead
-            # run the armv7 image.
-            export DOCKER_DEFAULT_PLATFORM=linux/arm64
             docker pull cgr.dev/chainguard/crane:latest
             docker images cgr.dev/chainguard/crane
             docker run --pull=never --rm cgr.dev/chainguard/crane:latest \

--- a/.github/workflows/test-pinspawn.yml
+++ b/.github/workflows/test-pinspawn.yml
@@ -255,6 +255,8 @@ jobs:
           run: |
             #!/bin/bash -eux
 
+            docker manifest inspect cgr.dev/chainguard/crane:latest
+
             /usr/bin/containerd &
             /usr/bin/dockerd &
             sleep 10

--- a/.github/workflows/test-pinspawn.yml
+++ b/.github/workflows/test-pinspawn.yml
@@ -259,7 +259,7 @@ jobs:
 
             # Note: GitHub's arm64 runner is armv8, but crane only has armv7 images; so we instead
             # run the armv7 image.
-            export DOCKER_DEFAULT_PLATFORM=linux/arm/v7
+            export DOCKER_DEFAULT_PLATFORM=linux/arm64
             docker pull cgr.dev/chainguard/crane:latest
             docker images cgr.dev/chainguard/crane
             docker run --pull=never --rm cgr.dev/chainguard/crane:latest \

--- a/.github/workflows/test-pinspawn.yml
+++ b/.github/workflows/test-pinspawn.yml
@@ -195,21 +195,6 @@ jobs:
               exit 666
             fi
 
-      # Run a slow script in a booted container
-
-      - name: Run slow script in booted container
-        uses: ./
-        if: ${{ ! endsWith(matrix.os, '-arm') }}
-        with:
-          image: rpi-os-image.img
-          boot: true
-          run: |
-            for i in {1..12}; do
-              echo "sleeping..."
-              sleep 10
-            done
-            /usr/games/cowsay "done!"
-
       # Check cgroup version
 
       - name: Confirm use of cgroup v2

--- a/.github/workflows/test-pinspawn.yml
+++ b/.github/workflows/test-pinspawn.yml
@@ -148,7 +148,7 @@ jobs:
       - name: Upload the bootup timeline to Job Artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: installed-packages
+          name: installed-packages-${{ matrix.os }}
           path: installed-packages.txt
           if-no-files-found: error
           overwrite: true
@@ -176,7 +176,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: ${{ ! endsWith(matrix.os, '-arm') }}
         with:
-          name: bootup-timeline
+          name: bootup-timeline-${{ matrix.os }}
           path: bootup-timeline.svg
           if-no-files-found: error
           overwrite: true
@@ -253,7 +253,10 @@ jobs:
           image: rpi-os-image.img
           args: --capability=CAP_NET_ADMIN
           run: |
+            #!/bin/bash -eux
+
             /usr/bin/containerd &
+            sleep 5
             /usr/bin/dockerd &
             sleep 10
 

--- a/.github/workflows/test-pinspawn.yml
+++ b/.github/workflows/test-pinspawn.yml
@@ -157,7 +157,7 @@ jobs:
 
       - name: Analyze systemd boot process
         uses: ./
-        if: ${{ endsWith(matrix.os, '-arm') }}
+        if: ${{ ! endsWith(matrix.os, '-arm') }}
         with:
           image: rpi-os-image.img
           args: --bind "$(pwd)":/run/external
@@ -174,7 +174,7 @@ jobs:
 
       - name: Upload the bootup timeline to Job Artifacts
         uses: actions/upload-artifact@v4
-        if: ${{ endsWith(matrix.os, '-arm') }}
+        if: ${{ ! endsWith(matrix.os, '-arm') }}
         with:
           name: bootup-timeline
           path: bootup-timeline.svg
@@ -199,7 +199,7 @@ jobs:
 
       - name: Run slow script in booted container
         uses: ./
-        if: ${{ endsWith(matrix.os, '-arm') }}
+        if: ${{ ! endsWith(matrix.os, '-arm') }}
         with:
           image: rpi-os-image.img
           boot: true

--- a/.github/workflows/test-pinspawn.yml
+++ b/.github/workflows/test-pinspawn.yml
@@ -227,7 +227,7 @@ jobs:
 
       - name: Install Docker
         uses: ./
-        if: ${{ endsWith(matrix.os, '-arm') }}
+        if: ${{ endsWith(matrix.os, '24.04-arm') }}
         with:
           image: rpi-os-image.img
           run: |
@@ -246,9 +246,9 @@ jobs:
             apt-get install -y \
               docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
 
-      - name: Pull and run a Docker container
+      - name: Inspect a Docker container image
         uses: ./
-        if: ${{ endsWith(matrix.os, '-arm') }}
+        if: ${{ endsWith(matrix.os, '24.04-arm') }}
         with:
           image: rpi-os-image.img
           args: --capability=CAP_NET_ADMIN
@@ -256,11 +256,7 @@ jobs:
             #!/bin/bash -eux
 
             /usr/bin/containerd &
-            sleep 5
             /usr/bin/dockerd &
             sleep 10
 
-            docker pull cgr.dev/chainguard/crane:latest
-            docker images cgr.dev/chainguard/crane
-            docker run --pull=never --rm cgr.dev/chainguard/crane:latest \
-              manifest cgr.dev/chainguard/crane:latest --platform=linux/amd64
+            docker manifest inspect cgr.dev/chainguard/crane:latest

--- a/.github/workflows/test-pinspawn.yml
+++ b/.github/workflows/test-pinspawn.yml
@@ -246,7 +246,7 @@ jobs:
             apt-get install -y \
               docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
 
-      - name: Run a Docker container image
+      - name: Pull a Docker container image
         uses: ./
         if: ${{ endsWith(matrix.os, '24.04-arm') }}
         with:
@@ -259,5 +259,5 @@ jobs:
             /usr/bin/dockerd &
             sleep 10
 
-            docker run hello-world
-            docker images hello-world
+            docker image pull hello-world
+            docker image ls

--- a/README.md
+++ b/README.md
@@ -142,8 +142,9 @@ Note: the system in the container will shut down after the specified commands fi
 
 ### Interact with Docker in an unbooted container
 
-Note: this example will *only* work if you run it in an arm64-based runner, e.g. `ubuntu-22.04-arm`
-or `ubuntu-24.04-arm`!
+Note: this example will *only* work if you run it in the `ubuntu-22.04-arm` runner; trying to run it
+on `ubuntu-24.04-arm` results in an error when `dockerd` tries to start
+(`failed to start daemon: Devices cgroup isn't mounted`).
 
 ```yaml
 - name: Install Docker
@@ -166,7 +167,7 @@ or `ubuntu-24.04-arm`!
       apt-get install -y \
         docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
 
-- name: Pull and run a Docker container
+- name: Inspect a Docker container image
   uses: ethanjli/pinspawn-action@v0.1.4
   with:
     image: rpi-os-image.img
@@ -179,10 +180,7 @@ or `ubuntu-24.04-arm`!
       /usr/bin/dockerd &
       sleep 10
 
-      docker pull cgr.dev/chainguard/crane:latest
-      docker images cgr.dev/chainguard/crane
-      docker run --pull=never --rm cgr.dev/chainguard/crane:latest \
-        manifest cgr.dev/chainguard/crane:latest --platform=linux/amd64
+      docker manifest inspect cgr.dev/chainguard/crane:latest
 ```
 
 ## Usage Options

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ on `ubuntu-24.04-arm` results in an error when `dockerd` tries to start
       apt-get install -y \
         docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
 
-- name: Run a Docker container image
+- name: Pull a Docker container image
   uses: ethanjli/pinspawn-action@v0.1.4
   with:
     image: rpi-os-image.img
@@ -180,8 +180,8 @@ on `ubuntu-24.04-arm` results in an error when `dockerd` tries to start
       /usr/bin/dockerd &
       sleep 10
 
-      docker run hello-world
-      docker images hello-world
+      docker image pull hello-world
+      docker image ls
 ```
 
 ## Usage Options

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ on `ubuntu-24.04-arm` results in an error when `dockerd` tries to start
       apt-get install -y \
         docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
 
-- name: Inspect a Docker container image
+- name: Run a Docker container image
   uses: ethanjli/pinspawn-action@v0.1.4
   with:
     image: rpi-os-image.img
@@ -180,7 +180,8 @@ on `ubuntu-24.04-arm` results in an error when `dockerd` tries to start
       /usr/bin/dockerd &
       sleep 10
 
-      docker manifest inspect cgr.dev/chainguard/crane:latest
+      docker run hello-world
+      docker images hello-world
 ```
 
 ## Usage Options

--- a/README.md
+++ b/README.md
@@ -176,9 +176,6 @@ or `ubuntu-24.04-arm`!
       /usr/bin/dockerd &
       sleep 10
 
-      # Note: GitHub's arm64 runner is armv8, but crane only has armv7 images; so we instead
-      # run the armv7 image.
-      export DOCKER_DEFAULT_PLATFORM=linux/arm/v7
       docker pull cgr.dev/chainguard/crane:latest
       docker images cgr.dev/chainguard/crane
       docker run --pull=never --rm cgr.dev/chainguard/crane:latest \

--- a/README.md
+++ b/README.md
@@ -172,7 +172,10 @@ or `ubuntu-24.04-arm`!
     image: rpi-os-image.img
     args: --capability=CAP_NET_ADMIN
     run: |
+      #!/bin/bash -eux
+
       /usr/bin/containerd &
+      sleep 5
       /usr/bin/dockerd &
       sleep 10
 

--- a/README.md
+++ b/README.md
@@ -9,10 +9,14 @@ name. It can also be used to boot the image's init program (which is usually sys
 action makes it easy to run a set of shell commands whether or not the OS is booted in the
 container.
 
-Note that you cannot start or interact with the Docker daemon inside a container booted with
-`systemd-nspawn`; instead, you should perform those operations inside a booted QEMU VM attached to
-your image, e.g. using the [`ethanjli/piqemu-action`](https://github.com/ethanjli/piqemu-action)
-GitHub action.
+Note that currently only unbooted containers work correctly on GitHub's new hosted arm64 runners;
+booted containers spontaneously initiate shutdown as soon as the system boot sequence reaches the
+login prompt. Maybe that's a bug which will magically go away after the hosted arm64 runners exit
+public preview (this is wishful thinking). For now, if you want to start or interact with the Docker
+daemon inside a container on an arm64 runner, you will need instantiate the container with the
+`CAP_NET_ADMIN` capability (to make iptables work) and then manually start both containerd (by
+launching `/usr/bin/containerd`) and the Docker daemon (by launching `/usr/bin/dockerd`). See the
+example listed below for an illustration of this.
 
 ## Basic Usage Examples
 
@@ -20,7 +24,7 @@ GitHub action.
 
 ```yaml
 - name: Install and run cowsay
-  uses: ethanjli/pinspawn-action@v0.1.3
+  uses: ethanjli/pinspawn-action@v0.1.4
   with:
     image: rpi-os-image.img
     run: |
@@ -33,7 +37,7 @@ GitHub action.
 
 ```yaml
 - name: Run in Python
-  uses: ethanjli/pinspawn-action@v0.1.3
+  uses: ethanjli/pinspawn-action@v0.1.4
   with:
     image: rpi-os-image.img
     shell: python
@@ -48,7 +52,7 @@ GitHub action.
 
 ```yaml
 - name: Run without root permissions
-  uses: ethanjli/pinspawn-action@v0.1.3
+  uses: ethanjli/pinspawn-action@v0.1.4
   with:
     image: rpi-os-image.img
     user: pi
@@ -74,7 +78,7 @@ GitHub action.
   run: chmod a+x figlet.sh
 
 - name: Run script directly
-  uses: ethanjli/pinspawn-action@v0.1.3
+  uses: ethanjli/pinspawn-action@v0.1.4
   with:
     image: rpi-os-image.img
     args: --bind "$(pwd)":/run/external
@@ -94,7 +98,7 @@ GitHub action.
       dtoverlay=i2c-rtc,rv3028,trickle-resistor-ohms=3000,backup-switchover-mode=1
 
 - name: Modify bootloader configuration
-  uses: ethanjli/pinspawn-action@v0.1.3
+  uses: ethanjli/pinspawn-action@v0.1.4
   with:
     image: rpi-os-image.img
     args: --bind "$(pwd)":/run/external
@@ -112,7 +116,7 @@ Note: the system in the container will shut down after the specified commands fi
 
 ```yaml
 - name: Analyze systemd boot process
-  uses: ethanjli/pinspawn-action@v0.1.3
+  uses: ethanjli/pinspawn-action@v0.1.4
   with:
     image: rpi-os-image.img
     args: --bind "$(pwd)":/run/external
@@ -134,6 +138,47 @@ Note: the system in the container will shut down after the specified commands fi
     path: bootup-timeline.svg
     if-no-files-found: error
     overwrite: true
+```
+
+### Interact with Docker in an unbooted container
+
+Note: this example will *only* work if you run it in an arm64-based runner, e.g. `ubuntu-22.04-arm`
+or `ubuntu-24.04-arm`!
+
+```yaml
+- name: Install Docker
+  uses: ethanjli/pinspawn-action@v0.1.4
+  with:
+    image: rpi-os-image.img
+    run: |
+      export DEBIAN_FRONTEND=noninteractive
+      apt-get update
+      apt-get install -y ca-certificates curl
+      install -m 0755 -d /etc/apt/keyrings
+      curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc
+      chmod a+r /etc/apt/keyrings/docker.asc
+      echo \
+        "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian \
+        $(. /etc/os-release && echo "$VERSION_CODENAME") stable" \
+        > /etc/apt/sources.list.d/docker.list
+      apt-get update
+      apt-get install -y \
+        docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+
+- name: Pull and run a container
+  uses: ethanjli/pinspawn-action@v0.1.4
+  with:
+    image: rpi-os-image.img
+    args: --capability=CAP_NET_ADMIN
+    run: |
+      /usr/bin/containerd &
+      /usr/bin/dockerd &
+      sleep 10
+
+      docker pull cgr.dev/chainguard/crane:latest
+      docker images cgr.dev/chainguard/crane
+      docker run --pull=never --rm cgr.dev/chainguard/crane:latest \
+        manifest cgr.dev/chainguard/crane:latest --platform=linux/amd64
 ```
 
 ## Usage Options

--- a/README.md
+++ b/README.md
@@ -158,14 +158,15 @@ or `ubuntu-24.04-arm`!
       curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc
       chmod a+r /etc/apt/keyrings/docker.asc
       echo \
-        "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian \
+        "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] \
+        https://download.docker.com/linux/debian \
         $(. /etc/os-release && echo "$VERSION_CODENAME") stable" \
         > /etc/apt/sources.list.d/docker.list
       apt-get update
       apt-get install -y \
         docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
 
-- name: Pull and run a container
+- name: Pull and run a Docker container
   uses: ethanjli/pinspawn-action@v0.1.4
   with:
     image: rpi-os-image.img
@@ -175,6 +176,9 @@ or `ubuntu-24.04-arm`!
       /usr/bin/dockerd &
       sleep 10
 
+      # Note: GitHub's arm64 runner is armv8, but crane only has armv7 images; so we instead
+      # run the armv7 image.
+      export DOCKER_DEFAULT_PLATFORM=linux/arm/v7
       docker pull cgr.dev/chainguard/crane:latest
       docker images cgr.dev/chainguard/crane
       docker run --pull=never --rm cgr.dev/chainguard/crane:latest \


### PR DESCRIPTION
This PR follows up on #3 by taking what I learned in https://github.com/PlanktoScope/PlanktoScope/pull/520 and simplifying it into an example for the README (and a CI test) to run and interact with Docker inside an unbooted nspawn container on an arm64-based GitHub-hosted runner.